### PR TITLE
Fixes target column name

### DIFF
--- a/making-your-first-submission-on-numerai.ipynb
+++ b/making-your-first-submission-on-numerai.ipynb
@@ -113,7 +113,7 @@
         "*   era: a period of time\n",
         "*   data_type: either `train`, `validation`, `test`, or `live` \n",
         "*   feature_*: abstract financial features of the stock \n",
-        "*   target_kazutsugi: abstract measure of stock performance\n",
+        "*   target: abstract measure of stock performance\n",
         "\n",
         "\n"
       ]
@@ -238,7 +238,7 @@
               "      <th>feature_wisdom44</th>\n",
               "      <th>feature_wisdom45</th>\n",
               "      <th>feature_wisdom46</th>\n",
-              "      <th>target_kazutsugi</th>\n",
+              "      <th>target</th>\n",
               "    </tr>\n",
               "  </thead>\n",
               "  <tbody>\n",
@@ -668,7 +668,7 @@
               "</div>"
             ],
             "text/plain": [
-              "                 id   era  ... feature_wisdom46  target_kazutsugi\n",
+              "                 id   era  ... feature_wisdom46  target\n",
               "0  n000315175b67977  era1  ...             0.75              0.75\n",
               "1  n0014af834a96cdd  era1  ...             1.00              0.25\n",
               "2  n001c93979ac41d4  era1  ...             0.75              0.00\n",
@@ -805,7 +805,7 @@
               "      <th>feature_wisdom44</th>\n",
               "      <th>feature_wisdom45</th>\n",
               "      <th>feature_wisdom46</th>\n",
-              "      <th>target_kazutsugi</th>\n",
+              "      <th>target</th>\n",
               "    </tr>\n",
               "  </thead>\n",
               "  <tbody>\n",
@@ -1235,7 +1235,7 @@
               "</div>"
             ],
             "text/plain": [
-              "                 id     era  ... feature_wisdom46  target_kazutsugi\n",
+              "                 id     era  ... feature_wisdom46  target\n",
               "0  n0003aa52cab36c2  era121  ...             0.00              0.00\n",
               "1  n000920ed083903f  era121  ...             0.50              0.25\n",
               "2  n0038e640522c4a6  era121  ...             0.00              1.00\n",
@@ -1305,7 +1305,7 @@
       "source": [
         "# create a model and fit the training data (~30 sec to run)\n",
         "model = sklearn.linear_model.LinearRegression()\n",
-        "model.fit(training_features, training_data.target_kazutsugi)"
+        "model.fit(training_features, training_data.target)"
       ],
       "execution_count": 0,
       "outputs": [


### PR DESCRIPTION
The source data has changed schema (renamed column `target_kazutsugi` to `target`). I noticed this on the first submission notebook, but many other notebooks here have the same issue.