### PR TITLE
Remove yfinance fork comment

### DIFF
--- a/signals/example_model.py
+++ b/signals/example_model.py
@@ -1,6 +1,4 @@
 import numerapi
-# a fork of yfinance that implements retries nicely
-# pip install -e git+http://github.com/leonhma/yfinance.git@master#egg=yfinance
 import yfinance
 import simplejson
 


### PR DESCRIPTION
The fork mentioned in the comment hasn't been updated for months, and no longer works as it doesn't supply a user-agent header in its requests