### PR TITLE
Fix range of embargo

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -84,7 +84,7 @@ def get_time_series_cross_val_splits(data, cv = 3, embargo = 12):
         # one era is length 5, so we need to embargo by target_length/5 eras.
         # To be consistent for all targets, let's embargo everything by 60/5 == 12 eras.
         train_split = [e for e in train_split_not_embargoed if
-                       abs(int(e) - test_split_max) > embargo and abs(int(e) - test_split_min) > embargo]
+                       abs(int(e) - test_split_max) >= embargo and abs(int(e) - test_split_min) >= embargo]
         train_splits.append(train_split)
 
     # convenient way to iterate over train and test splits


### PR DESCRIPTION
I fix comparison operators in calculation for no leakage train split range.
Before fix, era5 in the article below is considered to overlap era1.

* reference article
  https://forum.numer.ai/t/super-massive-data-release-deep-dive/4053#new-data-2
  In this article case, `target_length` is `20`, `embargo` is `20 / 5 = 4 eras`
