### PR TITLE
Fix last test split

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -74,7 +74,7 @@ def get_time_series_cross_val_splits(data, cv = 3, embargo = 12):
     # fix the last test split to have all the last eras, in case the number of eras wasn't divisible by cv
     remainder = len(all_train_eras) % cv
     if remainder != 0:
-        test_splits[-1] = np.append(test_splits[-1], all_train_eras[-1])
+        test_splits[-1] = np.append(test_splits[-1], all_train_eras[-remainder:])
 
     train_splits = []
     for test_split in test_splits:

--- a/utils.py
+++ b/utils.py
@@ -72,7 +72,9 @@ def get_time_series_cross_val_splits(data, cv = 3, embargo = 12):
     len_split = len(all_train_eras) // cv
     test_splits = [all_train_eras[i * len_split:(i + 1) * len_split] for i in range(cv)]
     # fix the last test split to have all the last eras, in case the number of eras wasn't divisible by cv
-    test_splits[-1] = np.append(test_splits[-1], all_train_eras[-1])
+    remainder = len(all_train_eras) % cv
+    if remainder != 0:
+        test_splits[-1] = np.append(test_splits[-1], all_train_eras[-1])
 
     train_splits = []
     for test_split in test_splits:


### PR DESCRIPTION
There are two issues:
* The last test split includes duplicated era when the number of train eras is divisible by cv.
* The last test split includes only last one era when the number of train eras is not divisible by cv.

Simple test to check this Pull request.

```python
import unittest
import pandas as pd
from utils import get_time_series_cross_val_splits

class TestUtils(unittest.TestCase):

    def test_number_of_train_eras_is_divisible(self):
        training_data = pd.DataFrame(
            {
                'era': list(map(lambda num: str(num).zfill(4), range(1, 16))),
            }
        )
        expected_all_train_eras = [
            '0001', '0002', '0003', '0004',
            '0005', '0006', '0007', '0008',
            '0009', '0010', '0011', '0012',
            '0013', '0014', '0015',
        ]
        self.assertEqual(list(training_data.era.unique()), expected_all_train_eras)

        train_test_zip = get_time_series_cross_val_splits(training_data, cv=3, embargo=4)
        train_test_splits_list = [[train, test.tolist()] for train, test in train_test_zip]
        expected_train_test_splits_list = [
            [
                # train
                ['0010', '0011', '0012', '0013', '0014', '0015'],
                # test
                ['0001', '0002', '0003', '0004', '0005'],
            ],
            [
                # train
                ['0001', '0015'],
                # test
                ['0006', '0007', '0008', '0009', '0010'],
            ],
            [
                # train
                ['0001', '0002', '0003', '0004', '0005', '0006'],
                # test
                #['0011', '0012', '0013', '0014', '0015', '0015'] # before fix, 0015 is duplicated
                ['0011', '0012', '0013', '0014', '0015'], # after fix
            ]
        ]
        self.assertEqual(train_test_splits_list, expected_train_test_splits_list)

    def test_number_of_train_eras_is_not_divisible(self):
        training_data = pd.DataFrame(
            {
                'era': list(map(lambda num: str(num).zfill(4), range(1, 15))),
            }
        )
        expected_all_train_eras = [
            '0001', '0002', '0003', '0004',
            '0005', '0006', '0007', '0008',
            '0009', '0010', '0011', '0012',
            '0013', '0014',
        ]
        self.assertEqual(list(training_data.era.unique()), expected_all_train_eras)

        train_test_zip = get_time_series_cross_val_splits(training_data, cv=3, embargo=4)
        train_test_splits_list = [[train, test.tolist()] for train, test in train_test_zip]
        expected_train_test_splits_list = [
            [
                # train
                ['0009', '0010', '0011', '0012', '0013', '0014'],
                # test
                ['0001', '0002', '0003', '0004'],
            ],
            [
                # train
                ['0013', '0014'],
                # test
                ['0005', '0006', '0007', '0008'],
            ],
            [
                # train
                ['0001', '0002', '0003', '0004'],
                # test
                #['0009', '0010', '0011', '0012', '0014'], # before fix, 0013 is missing
                ['0009', '0010', '0011', '0012', '0013', '0014'], # after fix
            ]
        ]
        self.assertEqual(train_test_splits_list, expected_train_test_splits_list)

if __name__ == '__main__':
    unittest.main()
```