### PR TITLE
adding matplotlib to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ scikit-learn==0.24.2
 scipy==1.7.1
 six==1.16.0
 tabulate==0.8.9
+matplotlib>=3.4.1


### PR DESCRIPTION
If you want to follow along in the example script notebooks, matplotlib is needed.