### PR TITLE
Fixed fillna not working

### DIFF
--- a/example_model.py
+++ b/example_model.py
@@ -96,7 +96,7 @@ if nans_per_col.any():
     print(f"Number of nans per column this week: {nans_per_col[nans_per_col > 0]}")
     print(f"out of {total_rows} total rows")
     print(f"filling nans with 0.5")
-    tournament_data.loc[:, features].fillna(0.5, inplace=True)
+    tournament_data.loc[:, features] = tournament_data.loc[:, features].fillna(0.5)
 else:
     print("No nans in the features this week!")
 

--- a/example_model_advanced.py
+++ b/example_model_advanced.py
@@ -211,7 +211,7 @@ if tournament_data.loc[tournament_data["data_type"] == "live", feature_cols].isn
     print(f"Number of nans per column this week: {cols_w_nan[cols_w_nan > 0]}")
     print(f"out of {total_rows} total rows")
     print(f"filling nans with 0.5")
-    tournament_data.loc[:, feature_cols].fillna(0.5, inplace=True)
+    tournament_data.loc[:, feature_cols] = tournament_data.loc[:, feature_cols].fillna(0.5)
 else:
     print("No nans in the features this week!")
 


### PR DESCRIPTION
The current use of `fillna` doesn't work, it basically does nothing as it runs on a copy of the dataframe.

When using Pandas `fillna` with `inplace=True` it only works on a single column (see e.g. https://bleepcoder.com/websockify/194846226/bug-fillna-with-inplace-does-not-work-with-multiple-columns)

Thus, I am fixing this by assigning the columns to ones where the nans have been replaced.

Basic replication to test:

```python
import pandas as pd
test = pd.DataFrame({'a': [0, 1, 2, 3, None, 4], 'b': [0, 1, None, 3, 4, 5]})
test.loc[:, ['a', 'b']].fillna(42, inplace=True)
assert test.isnull().values.any()  # There are still NaNs
test.loc[:, ['a', 'b']] = test.loc[:, ['a', 'b']].fillna(42)
assert not test.isnull().values.any()  # No more NaNs
```