### PR TITLE
bug fix best_pred_col

### DIFF
--- a/example_model_advanced.py
+++ b/example_model_advanced.py
@@ -289,6 +289,15 @@ validation_stats = validation_metrics(validation_data, list(pred_cols)+list(ense
                                       fast_mode=False, target_col=TARGET_COL)
 print(validation_stats.to_markdown())
 
+# if rename best_pred_col including _downsample(x) naming part included
+val_tmp = [c for c in validation_data.columns if c.startswith("pred")]
+for col in range(len(val_tmp)):
+    if val_tmp[col].find(best_pred_col) == -1:
+        print("next_col")
+    else:
+        best_pred_col = val_tmp[col]
+        break
+
 # rename best model to prediction and rank from 0 to 1 to meet diagnostic/submission file requirements
 validation_data["prediction"] = validation_data[best_pred_col].rank(pct=True)
 live_data["prediction"] = live_data[best_pred_col].rank(pct=True)


### PR DESCRIPTION
When for example `pred_target_janet_v4_20` is the  `best_pred_col` variable. Than its unfindable in the validation_data at: `validation_data["prediction"] = validation_data[best_pred_col].rank(pct=True)`.
This is because here the column is defined as:  `pred_target_janet_v4_20_downsample(x)`.

Here is a fix.