### PR TITLE
Add footnote to README about not using python2.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ The official example scripts for the [Numerai](https://numer.ai/) Data Science T
 
 ```
 pip install -U pip && pip install -r requirements.txt
+# Make sure `python --version` says python 3
 python example_model.py
 ```
 


### PR DESCRIPTION
Some systems default `python` executable to python2.7 . This tripped me up and then I used `python3 example_model.py` instead.