### PR TITLE
Use different var name to test feature subsets

### DIFF
--- a/feature_neutralization.ipynb
+++ b/feature_neutralization.ipynb
@@ -1536,8 +1536,8 @@
    ],
    "source": [
     "for group in groups:\n",
-    "    feature_subset = list(subgroups[\"medium\"][group])\n",
-    "    neutralized = validation.groupby(\"era\").apply(lambda d: neutralize(d[\"prediction\"], d[feature_subset]))\n",
+    "    neutralize_feature_subset = list(subgroups[\"medium\"][group])\n",
+    "    neutralized = validation.groupby(\"era\").apply(lambda d: neutralize(d[\"prediction\"], d[neutralize_feature_subset]))\n",
     "    validation[f\"neutralized_{group}\"] = neutralized.reset_index().set_index(\"id\")[\"prediction\"] \n",
     "\n",
     "prediction_cols2 = [\"prediction\"] + [f\"neutralized_{group}\" for group in groups]\n",


### PR DESCRIPTION
See issue feature_subset actually submits medium/all neutralized #150:

feature_subset is initially set to medium/serenity, the intended neutralization:

feature_subset = list(subgroups["medium"]["serenity"])

But later in the neutralizing different groups section is used in the for loop and ends on medium/all, which is then pickled in the submission.

for group in groups:
feature_subset = list(subgroups["medium"][group])