### PR TITLE
Fixed error in computing mean correlation with cyrus target

### DIFF
--- a/target_ensemble.ipynb
+++ b/target_ensemble.ipynb
@@ -2977,7 +2977,7 @@
         "  )\n",
         "  # per era correlation between this target and cyrus\n",
         "  mean_corr_with_cryus = validation.groupby(\"era\").apply(\n",
-        "      lambda d: d[target].corr(d[\"target_cyrus_v4_20\"])\n",
+        "      lambda d: d[pred_col].corr(d[\"target_cyrus_v4_20\"])\n",
         "  ).mean()\n",
         "  target_summary_metrics[pred_col].update({\n",
         "      \"mean_corr_with_cryus\": mean_corr_with_cryus\n",


### PR DESCRIPTION
There was an error in computing the mean correlation of the selected alternative targets with the crysus target in the "Evaluating the performance of each model" section