### PR TITLE
pandas/pyarrow conflict on colab

### DIFF
--- a/hello_numerai.ipynb
+++ b/hello_numerai.ipynb
@@ -57,8 +57,9 @@
       "outputs": [],
       "source": [
         "# Install dependencies\n",
-        "!pip install -q --upgrade numerapi pandas pyarrow matplotlib lightgbm scikit-learn scipy cloudpickle==3.1.1\n",
-        "!pip install -q --no-deps numerai-tools\n",
+        "!pip install pandas==2.2.2 pyarrow==19.0.0\n",
+        "!pip install numerapi matplotlib lightgbm scikit-learn scipy cloudpickle==3.1.1\n",
+        "!pip install --no-deps numerai-tools\n",
         "\n",
         "# Inline plots\n",
         "%matplotlib inline"


### PR DESCRIPTION
Current imports conflict with the colab's built in packages.

Error log:

ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
google-colab 1.0.0 requires pandas==2.2.2, but you have pandas 2.3.3 which is incompatible.
dask-cudf-cu12 25.6.0 requires pandas<2.2.4dev0,>=2.0, but you have pandas 2.3.3 which is incompatible.
cudf-cu12 25.6.0 requires pandas<2.2.4dev0,>=2.0, but you have pandas 2.3.3 which is incompatible.
cudf-cu12 25.6.0 requires pyarrow<20.0.0a0,>=14.0.0; platform_machine == "x86_64", but you have pyarrow 21.0.0 which is incompatible.
pylibcudf-cu12 25.6.0 requires pyarrow<20.0.0a0,>=14.0.0; platform_machine == "x86_64", but you have pyarrow 21.0.0 which is incompatible.