### PR TITLE
Fix example scripts workflow

### DIFF
--- a/.github/workflows/build-models.yml
+++ b/.github/workflows/build-models.yml
@@ -66,23 +66,25 @@ jobs:
             --execute crypto/example_model.ipynb \
             --ExecutePreprocessor.timeout=-1 \
             --to html
-      - name: delete-html
+      - name: delete-generated-files
         run: |
-          rm numerai/example_model.html
-          rm numerai/hello_numerai.html
-          rm numerai/feature_neutralization.html
-          rm numerai/target_ensemble.html
-          rm signals/example_model.html
-          rm crypto/example_model.html
-      - name: move-pickles-to-cached-pickles-dir
+          rm -f numerai/example_model.html
+          rm -f numerai/hello_numerai.html
+          rm -f numerai/feature_neutralization.html
+          rm -f numerai/target_ensemble.html
+          rm -f signals/example_model.html
+          rm -f signals/signals_example_preds.csv
+          rm -f signals_example_preds.csv
+          rm -f crypto/example_model.html
+          rm -f crypto/crypto_example_preds.csv
+          rm -f crypto_example_preds.csv
+      - name: move-numerai-pickles-to-cached-pickles-dir
         run: |
           mkdir -p cached-pickles/
           mv -f numerai/example_model.pkl cached-pickles/
           mv -f numerai/hello_numerai.pkl cached-pickles/
           mv -f numerai/feature_neutralization.pkl cached-pickles/
           mv -f numerai/target_ensemble.pkl cached-pickles/
-          mv -f signals/example_model.pkl cached-pickles/signals_example_model.pkl
-          mv -f crypto/example_model.pkl cached-pickles/crypto_example_model.pkl
       - name: commit-to-master
         uses: EndBug/add-and-commit@v9
         with:

--- a/numerai/feature_neutralization.ipynb
+++ b/numerai/feature_neutralization.ipynb
@@ -73,7 +73,7 @@
    ],
    "source": [
     "# Install dependencies\n",
-    "!pip install -q --upgrade numerapi pandas pyarrow matplotlib lightgbm scikit-learn scipy cloudpickle==3.1.1\n",
+    "!pip install -q --upgrade numerapi pandas==2.3.1 pyarrow matplotlib lightgbm scikit-learn scipy cloudpickle==3.1.1\n",
     "\n",
     "# Inline plots\n",
     "%matplotlib inline"
@@ -118,16 +118,6 @@
     "outputId": "b8d0557f-ae8f-48e8-e707-806ac4683ad4"
    },
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2025-12-14 14:28:07,202 INFO numerapi.utils: target file already exists\n",
-      "2025-12-14 14:28:07,203 INFO numerapi.utils: download complete\n",
-      "/var/folders/9t/l_bbq0y57ns1020jcy_lxsfm0000gn/T/ipykernel_32617/636407109.py:39: FutureWarning: DataFrame.applymap has been deprecated. Use DataFrame.map instead.\n",
-      "  pd.DataFrame(subgroups).applymap(len).sort_values(by=\"all\", ascending=False)\n"
-     ]
-    },
     {
      "data": {
       "text/html": [
@@ -270,7 +260,7 @@
     "        )\n",
     "\n",
     "# convert to data frame and display the feature count of each intersection\n",
-    "pd.DataFrame(subgroups).applymap(len).sort_values(by=\"all\", ascending=False)"
+    "pd.DataFrame(subgroups).map(len).sort_values(by=\"all\", ascending=False)"
    ]
   },
   {

--- a/numerai/hello_numerai.ipynb
+++ b/numerai/hello_numerai.ipynb
@@ -75,7 +75,7 @@
    ],
    "source": [
     "# Install dependencies\n",
-    "!pip install -q --upgrade numerapi pandas pyarrow matplotlib lightgbm scikit-learn scipy cloudpickle==3.1.1\n",
+    "!pip install -q --upgrade numerapi pandas==2.3.1 pyarrow matplotlib lightgbm scikit-learn scipy cloudpickle==3.1.1\n",
     "\n",
     "# Inline plots\n",
     "%matplotlib inline"

--- a/numerai/target_ensemble.ipynb
+++ b/numerai/target_ensemble.ipynb
@@ -80,7 +80,7 @@
    ],
    "source": [
     "# Install dependencies\n",
-    "!pip install -q --upgrade numerapi pandas pyarrow matplotlib lightgbm scikit-learn scipy cloudpickle==3.1.1\n",
+    "!pip install -q --upgrade numerapi pandas==2.3.1 pyarrow matplotlib lightgbm scikit-learn scipy cloudpickle==3.1.1\n",
     "\n",
     "# Inline plots\n",
     "%matplotlib inline"

--- a/signals/example_model.ipynb
+++ b/signals/example_model.ipynb
@@ -15,7 +15,7 @@
       },
       "outputs": [],
       "source": [
-        "!pip install -q numerapi lightgbm pyarrow scikit-learn scipy matplotlib\n",
+        "!pip install -q numerapi pandas==2.3.1 lightgbm pyarrow scikit-learn scipy matplotlib\n",
         "# make sure you restart your kernel session before continuing"
       ]
     },


### PR DESCRIPTION
## Summary
- Pin pandas to 2.3.1 in the remaining notebooks so notebook installs stay aligned with the Numerai Python 3.12 runtime.
- Replace the removed pandas `DataFrame.applymap` call in `feature_neutralization.ipynb` with `DataFrame.map`.
- Stop the workflow from moving Signals/Crypto pickle files that those notebooks no longer generate, and clean generated CSV outputs instead.

## Root Cause
The workflow executes notebooks that install unpinned pandas. Current pandas 3 removes `DataFrame.applymap`, which breaks `feature_neutralization.ipynb`. The workflow also expected Signals and Crypto pickle artifacts even though those notebooks now write prediction CSVs.

## Validation
- `git diff --cached --check`
- workflow YAML parse
- notebook JSON parse for all notebooks
- nbconvert smoke of the previously failing feature-neutralization setup cells

I did not run the full workflow locally because it downloads multi-GB Numerai datasets.